### PR TITLE
make sidebar buttons clickable

### DIFF
--- a/scripts/manage.js
+++ b/scripts/manage.js
@@ -46,13 +46,13 @@ function loadSidebar() {
 
 	sideBar();
 	bars = sidebar.getElementsByTagName('*');
-	
-	bars[slideNum * 3].className = 'bar-select';
+
+	bars[slideNum * 4].className = 'bar-select';
 }
 
 //creates sidebar menu
 function sideBar() {
-	
+
 	//holds current section
 	var section;
 
@@ -60,16 +60,19 @@ function sideBar() {
 
 		//create generic elements
 		var bar = document.createElement('div');
+		var barinner = document.createElement('div');
 		var anchor = document.createElement('a');
 		var span = document.createElement('span');
 		var text = document.createTextNode(slides[i].til);
 		var num = document.createTextNode(i);
 
-		anchor.appendChild(text);
 		span.appendChild(num);
-		bar.appendChild(span);
+		barinner.appendChild(span);
+		barinner.appendChild(text);
+		anchor.appendChild(barinner);
 		bar.appendChild(anchor);
-		
+
+		barinner.className = 'bar-inner';
 		span.className = 'bar-number';
 
 		anchor.href = 'javascript:void(0)';
@@ -119,10 +122,10 @@ function loadContent() {
 
 	//title
 	var title = document.createElement('div');
-	
+
 	title.insertAdjacentHTML('afterbegin', currentSlide.til);
 	title.style.color = currentSlide.col;
-	
+
 	if (currentSlide.sho !== "false") {
 		if (currentSlide.con.length == 0) {
 			title.className = 'content-big-title';

--- a/styles/style.css
+++ b/styles/style.css
@@ -115,10 +115,21 @@ a:hover {
 .bar-slide,
 .bar-section,
 .bar-select {
+
+	background-color: #333;
+	min-height: 40px;
+}
+
+#side > * > a {
+	display: block;
+	min-height: 40px;
+}
+
+.bar-inner {
 	padding: 10px;
 	padding-top: calc(20px - 7px);
 	padding-bottom: calc(20px - 7px);
-	background-color: #333;
+	width: 100%;
 	min-height: 40px;
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -115,7 +115,7 @@ a:hover {
 .bar-slide,
 .bar-section,
 .bar-select {
-
+	
 	background-color: #333;
 	min-height: 40px;
 }
@@ -173,10 +173,12 @@ a:hover {
 }
 
 .content-indent {
-	display: inline-block;
+	display: block;
 	padding-left: 20px;
-	border-left: solid 4px;
-	margin-top: 20px;
+}
+
+.content-indent:before{
+	content: '\2022\0000a0';
 }
 
 .notes {


### PR DESCRIPTION
within `sideBar()`, created `barinner`
made `text` a child of `barinner`
made `barinner` a child of `anchor`
made `anchor` a child of `bar`

changed logic to assign `className = 'bar-select'` to every 4th node instead of 3rd
changed css to fit anchor tag correctly (is now a block element)